### PR TITLE
Improve responsive menu

### DIFF
--- a/includes/enqueue-assets.php
+++ b/includes/enqueue-assets.php
@@ -23,8 +23,15 @@ function utility_pro_enqueue_assets() {
 	// Load mobile responsive menu
 	wp_enqueue_script( 'utility-pro-responsive-menu', get_stylesheet_directory_uri() . '/js/responsive-menu.js', array( 'jquery' ), '1.0.0', true );
 
+	$localize = array(
+		'buttonText'     => __( 'Menu', 'utility-pro' ),
+		'buttonLabel'    => __( 'Primary Navigation Menu', 'utility-pro' ),
+		'subButtonText'  => __( 'Menu', 'utility-pro' ),
+		'subButtonLabel' => __( 'Sub Navigation Menu', 'utility-pro' ),
+	);
+
 	// Localize the responsive menu script (for translation)
-	wp_localize_script( 'utility-pro-responsive-menu', 'utilityResponsiveL10n', array( 'button_label' => __( 'Menu', 'utility-pro' ) ) );
+	wp_localize_script( 'utility-pro-responsive-menu', 'utilityResponsiveL10n', $localize );
 
 	// Load scripts only if Genesis Accessible plugin is not active
 	if ( ! utility_pro_genesis_accessible_is_active() ) {

--- a/js/responsive-menu.js
+++ b/js/responsive-menu.js
@@ -1,21 +1,36 @@
+/* global utilityResponsiveL10n:false */
 ( function( window, $, undefined ) {
 	'use strict';
+	var primaryButton, subMenuButton;
 
-	$( '.menu-primary' ).before( '<button class="menu-toggle primary-menu-toggle" role="button" aria-pressed="false" aria-label="primary navigation menu"></button>' ); // Add toggles to menus
-	$( '.sub-menu' ).before( '<button class="menu-toggle sub-menu-toggle" role="button" aria-pressed="false" aria-label="sub-menu navigation"></button>' ); // Add toggles to sub menus
-	$( '.menu-primary' ).before( '<button class="menu-toggle primary-menu-toggle" role="button" aria-pressed="false"><span class="screen-reader-text">' + utilityResponsiveL10n.button_label + '</span></button>' ); // Add toggles to menus
-	$( '.sub-menu' ).before( '<button class="menu-toggle sub-menu-toggle" role="button" aria-pressed="false"></button>' ); // Add toggles to sub menus
+	primaryButton = $( '<button>' + utilityResponsiveL10n.buttonText + '</button>' )
+		.attr( 'role', 'button' )
+		.attr( 'aria-pressed', false )
+		.attr( 'aria-expanded', false )
+		.attr( 'aria-controls', $( '.menu-primary' ).attr( 'id' ) )
+		.attr( 'aria-label', utilityResponsiveL10n.buttonLabel )
+		.attr( 'class', 'menu-toggle menu-toggle-primary' );
+	$( '.menu-primary' ).before( primaryButton );
+
+	// Sub-level menu items
+	subMenuButton = $( '<button>' + utilityResponsiveL10n.subButtonText + '</button>' )
+		.attr( 'role', 'button' )
+		.attr( 'aria-pressed', false )
+		.attr( 'aria-label', utilityResponsiveL10n.subButtonLabel )
+		.attr( 'class', 'menu-toggle sub-menu-toggle' );
+	$( '.sub-menu' ).before( subMenuButton );
 
 	// Show/hide the navigation
 	$( '.menu-toggle, .sub-menu-toggle' ).on( 'click.utility-pro', function() {
-		var $this = $( this );
-		$this.attr( 'aria-pressed', function( index, value ) {
-			return 'false' === value ? 'true' : 'false';
-		});
+		var $button = $( this ),
+			state = 'false' === $button.attr( 'aria-pressed' ) ? true : false;
 
-		$this.toggleClass( 'menu-toggle-activated' );
-		$this.next( '.menu-primary, .sub-menu' ).slideToggle( 'fast' );
+		$button.attr( 'aria-pressed', state).toggleClass( 'menu-toggle-activated' );
+		// Only toggle aria-expanded if top level button
+		if ( $button.is( '[aria-controls]' ) ) {
+			$button.attr( 'aria-expanded', state );
+		}
 
+		$button.next( '.menu-primary, .sub-menu' ).slideToggle( 'fast' ).attr( 'aria-hidden', ! state );
 	});
-
 })( this, jQuery );

--- a/style.css
+++ b/style.css
@@ -1242,8 +1242,7 @@ Site Navigation
 	position: relative;
 }
 
-.menu-toggle,
-.sub-menu-toggle {
+.menu-toggle {
 	color: #fff;
 	display: block;
 	font-size: 30px;
@@ -1251,20 +1250,16 @@ Site Navigation
 	overflow: hidden;
 	padding: 9px;
 	visibility: visible;
-}
-
-button.menu-toggle,
-button.sub-menu-toggle {
 	background-color: transparent;
 	border: 0;
 }
 
-button.sub-menu-toggle {
+.sub-menu-toggle {
+	position: absolute;
+	top: 0;
+	right: 0;
 	font-size: 14px;
 	padding: 16px;
-	position: absolute;
-	right: 0;
-	top: 0;
 }
 
 .menu-toggle:before {


### PR DESCRIPTION
- `aria-controls` added to primary menu toggle button.
- `aria-expanded` added to primary menu toggle button.
- `aria-label` added to sub menu toggle buttons.
- `aria-label` values localized from PHP.
- Sub menu button text added (this is visual only as screen readers will likely read `aria-label` content), localised from PHP.
- Slightly cleaner code for toggling `aria-pressed` and class.
- Addition of `aria-hidden`, so screen-readers don't see the hidden menus until they are toggled open.

The sub-menus `ul` elements don't have an ID, so we're not yet gettingsub-menu toggle buttons marked up as controlling them and toggling their `aria-expanded` attribute.
