### PR TITLE
Add grunt-potomo support

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -30,6 +30,24 @@ module.exports = function(grunt) {
 			}
 		},
 		/**
+		 * Po to Mo
+		 * https://github.com/axisthemes/grunt-potomo
+		 */
+		potomo: {
+			dist: {
+				files: [
+					{
+						expand: true,
+						cwd: 'languages',
+						src: ['*.po'],
+						dest: 'languages',
+						ext: '.mo',
+						nonull: true
+					}
+				]
+			}
+		},
+		/**
 		 * CSSJanus
 		 */
 		cssjanus: {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "matchdep": "^0.3.0",
     "cssjanus": "^1.1.0",
     "grunt-cssjanus": "~0.2.2",
+    "grunt-potomo": "~3.1.1",
     "grunt-wp-i18n": "~0.4.9",
     "grunt-exec": "~0.4.6"
   }


### PR DESCRIPTION
Using this requires gettext support. In Mac, install it with Homebrew:

`brew install gettext --force`

You may need to follow the on-screen instructions to link it up.

Add the path (with Homebrew it would be `/usr/local/Cellar/gettext/0.19.4/bin` to your `PATH`.
