### PR TITLE
Automate zip compression of standard and development versions of the theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-
-[core]
-
-	excludesfile = /Users/gary/.gitignore_global
+dist/

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -71,6 +71,50 @@ module.exports = function(grunt) {
 			tasks: [
 				'cssjanus'
 			]
+		},
+		// https://github.com/gruntjs/grunt-contrib-compress
+		compress: {
+			standard: {
+				options: {
+					archive: 'dist/<%= pkg.name %>-<%= pkg.version %>.zip'
+				},
+				files: [
+					{
+						expand: true,
+						cwd: '',
+						src: [ // Take this...
+							'**',
+							'!gruntfile.js',
+							'!package.json',
+							'!node_modules/**',
+							'!.sass-cache/**',
+							'!dist/**',
+							'!*.sublime*',
+							'!.DS_Store'
+						],
+						dest: '<%= pkg.name %>' // ...put it into this, then zip that up as ^^^
+					}
+				]
+			},
+			dev: {
+				options: {
+					archive: 'dist/<%= pkg.name %>-developer-<%= pkg.version %>.zip'
+				},
+				files: [
+					{
+						expand: true,
+						src: [
+							'**',
+							'!node_modules/**',
+							'!.sass-cache/**',
+							'!dist/**',
+							'!*.sublime*',
+							'!.DS_Store'
+						], // Take this...
+						dest: '<%= pkg.name %>' // ...put it into this, then zip that up as ^^^
+					}
+				]
+			}
 		}
 	});
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Utility-Pro",
+  "name": "utility-pro",
   "version": "1.0.0",
   "description": "Utility Pro is a child theme for the Genesis Framework.",
   "copyright": "2015",
@@ -9,9 +9,8 @@
     "grunt": "^0.4.5",
     "grunt-contrib-watch": "^0.6.1",
     "matchdep": "^0.3.0",
-    "cssjanus": "^1.1.0",
     "grunt-cssjanus": "~0.2.2",
-    "grunt-potomo": "~3.1.1",
+    "grunt-potomo": "~3.2.0",
     "grunt-wp-i18n": "~0.4.9",
     "grunt-exec": "~0.4.6",
     "grunt-contrib-compress": "~0.13.0"


### PR DESCRIPTION
Packages updated, so needs a one-off `npm install`. Then you can generate standard zip with:

`grunt compress:standard`

and development with:

`grunt compress:dev`

Both stored in `dist/` directory (which is ignored via `.gitignore`), named accordingly.

Fixes #7
