### PR TITLE
Fix skip links script code standards

### DIFF
--- a/js/genwpacc-skiplinks.js
+++ b/js/genwpacc-skiplinks.js
@@ -1,6 +1,6 @@
 /**
  * genesis-accessible skiplinks
- * https://github.com/cdils/utility-pro/blob/develop/js/genwpacc-skiplinks.js
+ * https://github.com/RRWD/genesis-accessible/
  * Version: 1.0
  * License: GPL-2.0+
  * License URI: http://www.opensource.org/licenses/gpl-license.php


### PR DESCRIPTION
Fix whitespace, use single quotes, add `use strict`.
