### PR TITLE
Fixed name discrepancies in localized property names for the responsive mnu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -164,15 +164,15 @@ function enqueue_assets() {
 	$localize_primary = [
 		'buttonText'     => __( 'Menu', 'utility-pro' ),
 		'buttonLabel'    => __( 'Primary Navigation Menu', 'utility-pro' ),
-		'subButtonText'  => __( 'Sub Menu', 'utility-pro' ),
-		'subButtonLabel' => __( 'Sub Menu', 'utility-pro' ),
+		'subMenuButtonText'  => __( 'Sub Menu', 'utility-pro' ),
+		'subMenuButtonLabel' => __( 'Sub Menu', 'utility-pro' ),
 	];
 
 	$localize_footer = [
 		'buttonText'     => __( 'Footer Menu', 'utility-pro' ),
 		'buttonLabel'    => __( 'Footer Navigation Menu', 'utility-pro' ),
-		'subButtonText'  => __( 'Sub Menu', 'utility-pro' ),
-		'subButtonLabel' => __( 'Sub Menu', 'utility-pro' ),
+		'subMenuButtonText'  => __( 'Sub Menu', 'utility-pro' ),
+		'subMenuButtonLabel' => __( 'Sub Menu', 'utility-pro' ),
 	];
 
 	// Localize the responsive menu script (for translation).


### PR DESCRIPTION
Fixes #112 for UP `2.0.0-dev`. Does not address the problem in previous versions of the theme. Pending the (hopefully quick) upcoming release of 2.0, I'm not inclined to roll out a fix for the current version of the theme.